### PR TITLE
ART-12521: Update gomod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/openshift/pf-status-relay
 
-go 1.22
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
Image build was failing on Konflux due to outdated go mod dependencies.

```
2025-04-18 16:49:18,778 ERROR The command "/root/.cache/cachi2/go/go1.21.0/bin/go mod vendor" failed
2025-04-18 16:49:18,778 ERROR STDERR:
go: downloading github.com/vishvananda/netlink v1.3.0
go: downloading go.uber.org/mock v0.5.1
go: downloading github.com/onsi/ginkgo v1.16.5
go: downloading github.com/onsi/gomega v1.37.0
go: downloading github.com/vishvananda/netns v0.0.4
go: downloading golang.org/x/sys v0.31.0
go: downloading github.com/google/go-cmp v0.7.0
go: downloading golang.org/x/net v0.37.0
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading github.com/nxadm/tail v1.4.8
go: downloading gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: downloading github.com/fsnotify/fsnotify v1.4.9
go: downloading golang.org/x/text v0.23.0
go: updates to go.mod needed; to update it:
	go mod tidy
2025-04-18 16:49:18,778 ERROR Failed to fetch gomod dependencies
```
